### PR TITLE
Fix `res.send()` without arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ express.response.send = function expressmongoose_send () {
     return args[0].exec(handleResult);
   }
 
-  if ('Object' == args[0].constructor.name) {
+  if (args[0] && 'Object' == args[0].constructor.name) {
     return resolve(args[0], handleResult);
   }
 


### PR DESCRIPTION
Vanilla `res.send()` without arguments should return HTTP 200 with no body, but before this patch express-mongoose was crashing with the following error:

```
TypeError: Cannot read property 'constructor' of undefined
    at ServerResponse.expressmongoose_send [as send]
    (/path/to/node_modules/express-mongoose/index.js:69:26)
```
